### PR TITLE
Adding automated builds.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: jenkins-agent-amazonlinux2-nodejs14
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to Packages Container registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - run: echo "TODAY=$(date +"%Y.%m.%d")" >> $GITHUB_ENV
+    - name: build :${{env.TODAY}} image
+      run: |
+        docker build -t ghcr.io/harrymckillen/jenkins-agent-amazonlinux2-nodejs14:${{env.TODAY}} .
+    - name: publish jenkins-agent-amazonlinux2-nodejs14:${{env.TODAY}} image
+      run: |
+        docker push ghcr.io/harrymckillen/jenkins-agent-amazonlinux2-nodejs14:${{env.TODAY}}
+        docker tag ghcr.io/harrymckillen/jenkins-agent-amazonlinux2-nodejs14:${{env.TODAY}} ghcr.io/lazzurs/jenkins-agent-amazonlinux2-nodejs14:latest
+        docker push ghcr.io/harrymckillen/jenkins-agent-amazonlinux2-nodejs14:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lazzurs/jenkins-agent-amazonlinux2:latest
+FROM ghcr.io/lazzurs/jenkins-agent-amazonlinux2:latest
 
 ARG NVM_VERSION=v0.35.3
 ARG NODE_VERSION=14.17.0


### PR DESCRIPTION
Adding automated builds and pushing to github container repo so we can
pull without the rate limits that Docker Hub has.

This will do the build in GitHub in a transparent way that everyone can
see.